### PR TITLE
Update project name and bundle identifier

### DIFF
--- a/wild5/ios/wild5.xcodeproj/project.pbxproj
+++ b/wild5/ios/wild5.xcodeproj/project.pbxproj
@@ -1904,7 +1904,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.wild5wellness.kickstart30;
 				PRODUCT_NAME = wild5;
 				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -1939,7 +1939,7 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.wild5wellness.kickstart30;
 				PRODUCT_NAME = wild5;
 				TARGETED_DEVICE_FAMILY = 1;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/wild5/ios/wild5/Info.plist
+++ b/wild5/ios/wild5/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Wild5</string>
+	<string>KickStart30</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
@@ -76,8 +76,6 @@
 		<string>audio</string>
 		<string>remote-notification</string>
 	</array>
-	<key>kTCCServiceMediaLibrary</key>
-	<string>WE PLAY MUSIC</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>


### PR DESCRIPTION
I updated our project name to `KickStart30`. Not sure if this is right, but we can go with it for now. Also updated the bundle identifier to `com.wild5wellness.kickstart30`.

:memo: When you go to build the app again, it's going to install a whole new app. The old wild5 app can safely be deleted since it'll contain the old name and bundle identifier.