### PR TITLE
Fix stats bugs

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -91,7 +91,6 @@ const Routercomponent = () => {
         <Scene
           key="exercisetracking"
           backTitle="Back"
-          onBack={() => Actions.landing()}
           title="Exercise Tracking"
           component={ExerciseTracking}
         />
@@ -100,33 +99,28 @@ const Routercomponent = () => {
           backTitle="Back"
           title="Mindfulness Tracking"
           component={MindfulnessTracking}
-          onBack={() => Actions.landing()}
         />
         <Scene
           key="sleeptracking"
           backTitle="Back"
-          onBack={() => Actions.landing()}
           title="Sleep Tracking"
           component={SleepTracking}
         />
         <Scene
           key="socialtracking"
           backTitle="Back"
-          onBack={() => Actions.landing()}
           title="Social Tracking"
           component={SocialTracking}
         />
         <Scene
           key="nutritiontracking"
           backTitle="Back"
-          onBack={() => Actions.landing()}
           title="Nutrition Tracking"
           component={NutritionTracking}
         />
         <Scene
           key="herotracking"
           backTitle="Back"
-          onBack={() => Actions.landing()}
           title="HERO Tracking"
           component={HeroTracking}
         />

--- a/src/screens/statsscreens/EmptyState.js
+++ b/src/screens/statsscreens/EmptyState.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import PropTypes from 'prop-types';
+
+export const emptyState = (actionButton, isEmptyPredicateFn) => Component => {
+  function EmptyState(props) {
+    if (isEmptyPredicateFn(props)) {
+      return (
+        <View style={{alignItems: 'center'}}>
+          <Text style={{fontSize: 18, padding: 10, textAlign: 'center'}}>
+            We don't have any data to render these statistics.
+          </Text>
+          {actionButton}
+        </View>
+      );
+    }
+
+    return <Component {...props} />;
+  }
+
+  EmptyState.propTypes = {
+    princData: PropTypes.arrayOf(PropTypes.object).isRequired,
+  };
+
+  return EmptyState;
+};

--- a/src/screens/statsscreens/ExerciseStats.js
+++ b/src/screens/statsscreens/ExerciseStats.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import {View, Dimensions} from 'react-native';
+import {View, Dimensions, Button} from 'react-native';
 import {Text, Icon} from 'native-base';
+import {Actions} from 'react-native-router-flux';
 import countBy from 'lodash/countBy';
 import {withAuthProvider} from '../../context/authcontext';
 import {objectMax} from '../../utils/object';
+import {emptyState} from './EmptyState';
+import {compose} from '../../utils/array';
 
 const screenheight = Dimensions.get('window').height;
 
@@ -133,4 +136,16 @@ function ExerciseStats(props) {
   );
 }
 
-export default withAuthProvider(ExerciseStats);
+export default compose(
+  withAuthProvider,
+  emptyState(
+    <Button
+      onPress={() => Actions.exercisetracking()}
+      title="Add Exercise Data"
+    />,
+    props =>
+      Object.values(props.princData).filter(day =>
+        day.hasOwnProperty('exercise')
+      ).length === 0
+  )
+)(ExerciseStats);

--- a/src/screens/statsscreens/MindfulStats.js
+++ b/src/screens/statsscreens/MindfulStats.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import {View} from 'react-native';
+import {View, Button} from 'react-native';
 import {Text, Icon} from 'native-base';
+import {Actions} from 'react-native-router-flux';
 import countBy from 'lodash/countBy';
 import {withAuthProvider} from '../../context/authcontext';
 import {objectMax} from '../../utils/object';
+import {compose} from '../../utils/array';
+import {emptyState} from './EmptyState';
 
 function MindfulStats(props) {
   const favoriteMeditation = React.useMemo(() => {
@@ -59,4 +62,16 @@ function MindfulStats(props) {
   );
 }
 
-export default withAuthProvider(MindfulStats);
+export default compose(
+  withAuthProvider,
+  emptyState(
+    <Button
+      onPress={() => Actions.mindfulnesstracking()}
+      title="Add Mindfulness Data"
+    />,
+    props =>
+      Object.values(props.princData).filter(day =>
+        day.hasOwnProperty('mindfulness')
+      ).length === 0
+  )
+)(MindfulStats);

--- a/src/screens/statsscreens/NutrStats.js
+++ b/src/screens/statsscreens/NutrStats.js
@@ -1,14 +1,17 @@
 import React, {Component} from 'react';
-import {View, Dimensions, ScrollView} from 'react-native';
+import {View, Dimensions, ScrollView, Button} from 'react-native';
 import {Text, Icon} from 'native-base';
+import {Actions} from 'react-native-router-flux';
 import {withAuthProvider} from '../../context/authcontext';
 import BarGraph from '../../components/charts/NutriGraph';
+import {compose} from '../../utils/array';
+import {emptyState} from './EmptyState';
 
 //graph of all practices + scores
 
 const screenheight = Dimensions.get('window').height;
 
-class SleepStats extends Component {
+class NutritionStats extends Component {
   state = {
     logmeals: 0,
     MIND: 0,
@@ -196,4 +199,16 @@ class SleepStats extends Component {
   }
 }
 
-export default withAuthProvider(SleepStats);
+export default compose(
+  withAuthProvider,
+  emptyState(
+    <Button
+      onPress={() => Actions.nutritiontracking()}
+      title="Add Nutrition Data"
+    />,
+    props =>
+      Object.values(props.princData).filter(day =>
+        day.hasOwnProperty('nutrition')
+      ).length === 0
+  )
+)(NutritionStats);

--- a/src/screens/statsscreens/NutrStats.js
+++ b/src/screens/statsscreens/NutrStats.js
@@ -10,7 +10,12 @@ const screenheight = Dimensions.get('window').height;
 
 class SleepStats extends Component {
   state = {
-    best: 'None',
+    logmeals: 0,
+    MIND: 0,
+    breakfast: 0,
+    lunch: 0,
+    dinner: 0,
+    total: 0,
   };
 
   componentWillMount() {
@@ -30,7 +35,10 @@ class SleepStats extends Component {
   }
 
   calculateStats = () => {
-    let data = Object.values(this.props.princData);
+    let data = Object.values(this.props.princData).filter(day =>
+      day.hasOwnProperty('nutrition')
+    );
+
     this.renderGraph(data);
   };
 

--- a/src/screens/statsscreens/SleepStats.js
+++ b/src/screens/statsscreens/SleepStats.js
@@ -8,7 +8,13 @@ const screenheight = Dimensions.get('window').height;
 
 class SleepStats extends Component {
   state = {
-    best: 'None',
+    caff: 0,
+    elec: 0,
+    nap: 0,
+    regtime: 0,
+    mask: 0,
+    bath: 0,
+    total: 0,
   };
 
   componentWillMount() {
@@ -28,7 +34,10 @@ class SleepStats extends Component {
   }
 
   calculateStats = () => {
-    let data = Object.values(this.props.princData);
+    let data = Object.values(this.props.princData).filter(day =>
+      day.hasOwnProperty('sleep')
+    );
+
     this.renderGraph(data);
   };
 

--- a/src/screens/statsscreens/SleepStats.js
+++ b/src/screens/statsscreens/SleepStats.js
@@ -1,8 +1,11 @@
 import React, {Component} from 'react';
-import {View, Dimensions, ScrollView} from 'react-native';
+import {View, Dimensions, ScrollView, Button} from 'react-native';
 import {Text, Icon, Spinner} from 'native-base';
+import {Actions} from 'react-native-router-flux';
 import {withAuthProvider} from '../../context/authcontext';
 import BarGraph from '../../components/charts/SleepGraph';
+import {compose} from '../../utils/array';
+import {emptyState} from './EmptyState';
 
 const screenheight = Dimensions.get('window').height;
 
@@ -387,4 +390,12 @@ class SleepStats extends Component {
   }
 }
 
-export default withAuthProvider(SleepStats);
+export default compose(
+  withAuthProvider,
+  emptyState(
+    <Button onPress={() => Actions.sleeptracking()} title="Add Sleep Data" />,
+    props =>
+      Object.values(props.princData).filter(day => day.hasOwnProperty('sleep'))
+        .length === 0
+  )
+)(SleepStats);

--- a/src/screens/statsscreens/SocialStats.js
+++ b/src/screens/statsscreens/SocialStats.js
@@ -11,7 +11,10 @@ const screenheight = Dimensions.get('window').height;
 
 class SocialStats extends Component {
   state = {
-    best: 'None',
+    calledFriend: 0,
+    metFriendInPerson: 0,
+    calledFamily: 0,
+    metFamilyInPerson: 0,
   };
 
   componentWillMount() {
@@ -31,11 +34,15 @@ class SocialStats extends Component {
   }
 
   calculateStats = () => {
-    const data = Object.values(this.props.princData).map(day => day.social);
+    const data = Object.values(this.props.princData)
+      .filter(day => day.hasOwnProperty('social'))
+      .map(day => day.social);
+
     this.renderGraph(data);
   };
 
   renderGraph = data => {
+    console.log(data);
     const stats = data.reduce(
       (totals, activities) => {
         return mapValues(

--- a/src/screens/statsscreens/SocialStats.js
+++ b/src/screens/statsscreens/SocialStats.js
@@ -1,9 +1,12 @@
 import React, {Component} from 'react';
-import {View, Dimensions} from 'react-native';
+import {View, Dimensions, Button} from 'react-native';
 import {Text, Icon} from 'native-base';
+import {Actions} from 'react-native-router-flux';
 import mapValues from 'lodash/mapValues';
 import {withAuthProvider} from '../../context/authcontext';
 import BarGraph from '../../components/charts/SocialGraph';
+import {compose} from '../../utils/array';
+import {emptyState} from './EmptyState';
 
 //graph of all practices + scores
 
@@ -156,4 +159,12 @@ class SocialStats extends Component {
   }
 }
 
-export default withAuthProvider(SocialStats);
+export default compose(
+  withAuthProvider,
+  emptyState(
+    <Button onPress={() => Actions.socialtracking()} title="Add Social Data" />,
+    props =>
+      Object.values(props.princData).filter(day => day.hasOwnProperty('social'))
+        .length === 0
+  )
+)(SocialStats);

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,0 +1,5 @@
+export const compose = (...fns) => initial =>
+  fns.reduceRight((aggregate, fn) => fn(aggregate), initial);
+
+export const pipe = (...fns) => initial =>
+  fns.reduce((aggregate, fn) => fn(aggregate), initial);


### PR DESCRIPTION
Fixes a few of the stats bugs I was running into:

- Should now not throw an error when going to a stats tile that has no data on the backend.
- Should show an empty state if there is no data to show.

![image](https://user-images.githubusercontent.com/1574487/63825102-a23ed100-c916-11e9-852b-e5186690f5c1.png)
